### PR TITLE
Corrigindo transições

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -639,7 +639,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &353842003
 RectTransform:
   m_ObjectHideFlags: 0
@@ -648,7 +648,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 353842002}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -657,7 +657,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.080498}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &353842004
@@ -733,9 +733,9 @@ RectTransform:
   m_Father: {fileID: 1184501268}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -146.31891}
   m_SizeDelta: {x: 743.8, y: 67.2}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &370914229
@@ -915,7 +915,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2106898404}
-  - {fileID: 1514069165}
   - {fileID: 1131520347}
   - {fileID: 857563085}
   - {fileID: 1414388569}
@@ -926,6 +925,7 @@ RectTransform:
   - {fileID: 1669790136}
   - {fileID: 1852358179}
   - {fileID: 810272242}
+  - {fileID: 1514069165}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1354,7 +1354,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &810272242
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1373,8 +1373,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.09, y: -44}
-  m_SizeDelta: {x: 743.9, y: 176.37}
+  m_AnchoredPosition: {x: 1.3, y: -43}
+  m_SizeDelta: {x: 741.31, y: 176.37}
   m_Pivot: {x: 0.49999997, y: 0.5000001}
 --- !u!114 &810272243
 MonoBehaviour:
@@ -1475,7 +1475,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &857563085
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1484,7 +1484,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 857563084}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1493,7 +1493,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.026211, y: -0.091823}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.8, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &857563086
@@ -1907,7 +1907,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1042617981
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1916,7 +1916,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1042617980}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1925,7 +1925,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.080498}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1042617982
@@ -1983,7 +1983,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1131520347
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1992,7 +1992,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1131520346}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.082016, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2001,7 +2001,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.005188, y: -0.06788397}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.8, y: 19.191}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1131520348
@@ -2060,7 +2060,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1184501268
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2165,7 +2165,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1194274006
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2174,7 +2174,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1194274005}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2183,7 +2183,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.080498}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1194274007
@@ -2446,7 +2446,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1414388569
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2455,7 +2455,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1414388568}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2464,7 +2464,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0077311, y: -0.12078}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.8, y: 19.189}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1414388570
@@ -2516,7 +2516,6 @@ GameObject:
   - component: {fileID: 1514069165}
   - component: {fileID: 1514069168}
   - component: {fileID: 1514069167}
-  - component: {fileID: 1514069166}
   - component: {fileID: 1514069169}
   m_Layer: 5
   m_Name: FadeImage
@@ -2533,7 +2532,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1514069164}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2547,23 +2546,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1514069166
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1514069164}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cdbfe124e0574814684666919f8bb7f0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  animationEnabled: 1
-  blinkDuration: 3
-  textDuration: 3
-  minAlpha: 0
-  maxAlpha: 1
 --- !u!114 &1514069167
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2649,9 +2631,9 @@ RectTransform:
   m_Father: {fileID: 1184501268}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -67.20001}
   m_SizeDelta: {x: 743.8, y: 67.2}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1561543129
@@ -2908,7 +2890,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1669790136
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2917,7 +2899,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1669790135}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2926,7 +2908,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.080498}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1669790137
@@ -2984,7 +2966,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1782192975
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2993,7 +2975,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1782192974}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3002,7 +2984,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.020277}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.192}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1782192976
@@ -3197,7 +3179,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1852358179
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3206,7 +3188,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1852358178}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -12800.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 74.08201, y: 74.10283, z: 142.22223}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3215,7 +3197,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.68837, y: -0.080498}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10.82, y: 19.19}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1852358180
@@ -3291,9 +3273,9 @@ RectTransform:
   m_Father: {fileID: 1184501268}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -225.4378}
   m_SizeDelta: {x: 743.8, y: 67.2}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1924312752
@@ -3901,7 +3883,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3367965423700571637, guid: 22fce13ac9ba318439fa53aad94a2af1, type: 3}
       propertyPath: m_Size
-      value: 1
+      value: 0.9998433
       objectReference: {fileID: 0}
     - target: {fileID: 3367965423700571637, guid: 22fce13ac9ba318439fa53aad94a2af1, type: 3}
       propertyPath: m_Value
@@ -3917,7 +3899,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4679286954154883653, guid: 22fce13ac9ba318439fa53aad94a2af1, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1053.472
+      value: -1054.1665
+      objectReference: {fileID: 0}
+    - target: {fileID: 5632934118340301006, guid: 22fce13ac9ba318439fa53aad94a2af1, type: 3}
+      propertyPath: m_ScrollSensitivity
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7737304190529906059, guid: 22fce13ac9ba318439fa53aad94a2af1, type: 3}
       propertyPath: m_SizeDelta.x

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -40,15 +40,12 @@ public class GameManager : MonoBehaviour
 
     private float elapsedTime;
     private float elapsedTextTime;
-    public  GameObject fadeImageObject;
-    public  Image fadeImage;
+    public GameObject fadeImageObject;
+    public Image fadeImage;
     public TMP_Text textoFadeImage;
     public TMP_Text diaFadeImage;
     private bool reverse = false;
     private string posTransicao;
-
-    Color transparentBlack = new Color(0f, 0f, 0f, 0f);
-    Color solidBlack = new Color(0f, 0f, 0f, 1f);
 
     public TMP_Text dia;
     private string novoDia;
@@ -72,24 +69,13 @@ public class GameManager : MonoBehaviour
         textoBotao2 = botao2.GetComponentInChildren<TMP_Text>();
         textoBotao3 = botao3.GetComponentInChildren<TMP_Text>();
 
-        fadeImage.color = transparentBlack;
-        StartConversation();
         novoDia = "Qua 22:40";
         dia.text = novoDia;
 
-        notificacaoDia1.gameObject.SetActive(false);
-        notificacaoDia2.gameObject.SetActive(false);
-        notificacaoDia22.gameObject.SetActive(false);
-        notificacaoDia3.gameObject.SetActive(false);
-        notificacaoDia32.gameObject.SetActive(false);
-        notificacaoDia4.gameObject.SetActive(false);
-        notificacaoDia5.gameObject.SetActive(false);
-        notificacaoDia6.gameObject.SetActive(false);
-        notificacaoDia7.gameObject.SetActive(false);
-        botaoTransicao.gameObject.SetActive(false);
-
         SpriteRenderer cabecalhoSpriteRenderer = cabecalho.GetComponent<SpriteRenderer>();
         SpriteRenderer botoesFundoSpriteRenderer = botoesFundo.GetComponent<SpriteRenderer>();
+        
+        StartCoroutine(Chat1());
     }
 
     void Update()
@@ -125,27 +111,25 @@ public class GameManager : MonoBehaviour
                     minAlpha = temp;
                     elapsedTime = 0f;
                     elapsedTextTime = 0f;
-                    reverse = true;
-                    telasDeNotificacao();
+                    reverse = true;   
+                    telasDeNotificacao();    
                 }
                 else
                 {
                     //acabou
                     Debug.Log("Fim da transição");
                     animationEnabled = false;
+                    reverse = false;
+                    elapsedTime = 0f;
+                    elapsedTextTime = 0f;
+                    maxAlpha = 1f;
+                    minAlpha = 0f;
                     fadeImageObject.SetActive(false);
                     botaoTransicao.gameObject.SetActive(true);
-                    ConfigureButtonTransition();                   
+                    ConfigureButtonTransition();
                 }
             }
         }
-    }
-
-    public void StartConversation()
-    {
-        ButtonPanel.SetActive(false);
-     // StartCoroutine(FadeInScreen());
-        StartCoroutine(Chat1());
     }
 
     public IEnumerator Chat1()
@@ -2214,22 +2198,35 @@ public IEnumerator chat93()
         if(posTransicao == "chat36"){
             notificacaoDia1.gameObject.SetActive(true);
         }
+        
+        if(posTransicao == "chat465"){
+            notificacaoDia2.gameObject.SetActive(true);
+        }
     }
 
     
     public void OnBotaoTransicaoClick()
     {      
+        botaoTransicao.gameObject.SetActive(false);
+
         if(posTransicao == "chat36")
         {
-        botaoTransicao.gameObject.SetActive(false);
-        notificacaoDia1.gameObject.SetActive(false);
-        StartCoroutine(chat36());
+            notificacaoDia1.gameObject.SetActive(false);
+            StartCoroutine(chat36());
+        } 
+
+        if(posTransicao == "chat465")
+        {
+            notificacaoDia2.gameObject.SetActive(false);
+            StartCoroutine(chat465());
         }
+        
     }
 
     public void ConfigureButtonTransition()
-{
-    botaoTransicao.onClick.AddListener(OnBotaoTransicaoClick);
-}
+    {
+        botaoTransicao.onClick.RemoveAllListeners();
+        botaoTransicao.onClick.AddListener(OnBotaoTransicaoClick);
+    }
     
 }


### PR DESCRIPTION
Mudei a ordem das telas de notificação para ficarem atras da tela de transição
Deixei as telas de notificação desativadas por padrão pelo editor, ai não precisa desativar pelo código no Start() do Gamemaneger
O principal problema das transições estava acontecendo por dois motivos:
 1. Ao final da primeira transição não estava zerando muitas variaveis como elapsedTime elapsedTextTime minAlpha e maxAlpha
 2. O objeto de transição fadeImage tinha ainda o script "Blink" adicionado nele que ficava atrapalhando o controle do alpha da transição

Arrumei mais umas coisas no código no geral, acho que com o merge vai dar tudo certo